### PR TITLE
Get a document update

### DIFF
--- a/packages/firebase_snippets_app/lib/model/firestore_add_data_custom_objects_snippet.dart
+++ b/packages/firebase_snippets_app/lib/model/firestore_add_data_custom_objects_snippet.dart
@@ -32,16 +32,20 @@ class City {
     this.regions,
   });
 
-  City.fromFirestore(
+  factory City.fromFirestore(
     DocumentSnapshot<Map<String, dynamic>> snapshot,
     SnapshotOptions? options,
-  )   : name = snapshot.data()?["name"],
-        state = snapshot.data()?["state"],
-        country = snapshot.data()?["country"],
-        capital = snapshot.data()?["capital"],
-        population = snapshot.data()?["population"],
-        regions =
-            (snapshot.data()?["regions"] as List<dynamic>?)?.cast<String>();
+  ) {
+    final data = snapshot.data() as Map<String, dynamic>;
+    return City(
+      name: data['name'],
+      state: data['state'],
+      country: data['country'],
+      capital: data['capital'],
+      population: data['population'],
+      regions: data['regions'] as List<String>,
+    );
+  }
 
   Map<String, dynamic> toFirestore() {
     return {

--- a/packages/firebase_snippets_app/lib/snippets/firestore.dart
+++ b/packages/firebase_snippets_app/lib/snippets/firestore.dart
@@ -411,9 +411,12 @@ class FirestoreSnippets extends DocSnippet {
     // [START get_data_once_get_a_document]
     final docRef = db.collection("cities").doc("SF");
     docRef.get().then(
-          (res) => print("Successfully completed"),
-          onError: (e) => print("Error completing: $e"),
-        );
+      (DocumentSnapshot doc) {
+        final data = doc.data() as Map<String, dynamic>;
+        // ...
+      },
+      onError: (e) => print("Error getting document: $e"),
+    );
     // [END get_data_once_get_a_document]
   }
 


### PR DESCRIPTION
_Description of what this PR is changing or adding:_

copied from recommendation: "For other platforms we at least show how to get the data() of a document snapshot in the example snippets, but for Flutter that is missing. Ideally we'd also show how to get a specific field for Flutter though, as that is a bit more complex than for other platforms as the data() method returns a generic type T? in Flutter, rather than the more common Map<String, Object> of other platforms."


## Risk Level
- [x] No risk

## Pre-submit checklist
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)