### PR TITLE
Update firestore.dart

### DIFF
--- a/packages/firebase_snippets_app/lib/snippets/firestore.dart
+++ b/packages/firebase_snippets_app/lib/snippets/firestore.dart
@@ -847,7 +847,7 @@ class FirestoreSnippets extends DocSnippet {
 
   void paginateData_addASimpleCursor2() {
     // [START paginate_data_add_a_simple_cursor2]
-    db.collection("cities").orderBy("population").startAt([1000000]);
+    db.collection("cities").orderBy("population").endAt([1000000]);
     // [END paginate_data_add_a_simple_cursor2]
   }
 


### PR DESCRIPTION
_Description of what this PR is changing or adding:_

Paginate section in this page (https://firebase.google.com/docs/firestore/query-data/query-cursors#add_a_simple_cursor_to_a_query) introduces `startAt` and `endAt`.

This code should shows `endAt`, but do `startAt`.
https://github.com/firebase/snippets-flutter/blob/9aa78b2712cbbba289a68396bcd766297cb93c43/packages/firebase_snippets_app/lib/snippets/firestore.dart#L850-L850

_Issues fixed by this PR (if any):_

## Risk Level
- [ ] No risk
- [ ] Somewhat Risky
- [ ] High risk

## Pre-submit checklist
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)