### PR TITLE
fix not equal example

### DIFF
--- a/packages/firebase_snippets_app/lib/snippets/firestore.dart
+++ b/packages/firebase_snippets_app/lib/snippets/firestore.dart
@@ -661,7 +661,7 @@ class FirestoreSnippets extends DocSnippet {
   void performSimpleAndCompoundQueries_notEqual() {
     // [START perform_simple_and_compound_queries_not_equal]
     final citiesRef = db.collection("cities");
-    final notCapitals = citiesRef.where("capital", isNotEqualTo: true);
+    final notCapitals = citiesRef.where("capital", isNotEqualTo: false);
     // [END perform_simple_and_compound_queries_not_equal]
   }
 


### PR DESCRIPTION
_Description of what this PR is changing or adding:_
In examples of other languages, isNotEqualTo parameter's value is false. This causes misunderstanding according to the text.

_Issues fixed by this PR (if any):_

## Risk Level
- [ ] No risk
- [x] Somewhat Risky
- [ ] High risk

## Pre-submit checklist
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)