### PR TITLE
added count aggregation query snippets

### DIFF
--- a/packages/firebase_snippets_app/lib/snippets/firestore.dart
+++ b/packages/firebase_snippets_app/lib/snippets/firestore.dart
@@ -794,6 +794,33 @@ class FirestoreSnippets extends DocSnippet {
     // [END perform_simple_and_compound_queries_collection_groups2]
   }
 
+  void aggregationQuery_count() {
+    // [START count_aggregate_collection]
+    // Returns number of documents in users collection
+    db
+      .collection("users")
+      .count()
+      .then(
+        (res) => print(res.data().count), 
+        onError: (e) => print("Error completing: $e"),
+      );
+    // [END count_aggregate_collection]
+  }
+
+  void aggregationQuery_count2() {
+    // [START count_aggregate_query]
+    // This also works with collectionGroup queries.
+    db
+      .collection("users")
+      .where("age", isGreaterThan: 10)
+      .count()
+      .then(
+        (res) => print(res.data().count), 
+        onError: (e) => print("Error completing: $e"),
+      );
+    // [END count_aggregate_query]
+  }
+
   void orderAndLimitData_orderAndLimitData() {
     // [START order_and_limit_data_order_and_limit_data]
     final citiesRef = db.collection("cities");


### PR DESCRIPTION
Added code snippets of new `count()` aggregation query mentioned in the documentation [here](https://firebase.google.com/docs/firestore/query-data/aggregation-queries). 