### PR TITLE
Change `flutter format .` to `dart format .`

### DIFF
--- a/.github/workflows/scripts/drive-app.sh
+++ b/.github/workflows/scripts/drive-app.sh
@@ -7,5 +7,5 @@ TARGET_PATH="packages/$PROJECT_NAME/"
 pushd "$TARGET_PATH" || exit &&
 flutter clean &&
 flutter pub get &&
-flutter format . &&
+dart format . &&
 flutter test integration_test


### PR DESCRIPTION
`flutter format` shouldn't be used anymore:

```
[!] The "format" command is deprecated and will be removed in a future version of Flutter. Please use the "dart format" sub-command instead,
which takes all of the same command-line arguments as "flutter format".
```

## Risk Level
- [x] No risk
- [ ] Somewhat Risky
- [ ] High risk

## Pre-submit checklist
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)