### PR TITLE
docs: correct usage guidance for enabling persistence on web

### DIFF
--- a/packages/firebase_snippets_app/lib/snippets/firestore.dart
+++ b/packages/firebase_snippets_app/lib/snippets/firestore.dart
@@ -1069,12 +1069,8 @@ class FirestoreSnippets extends DocSnippet {
 
   void accessDataOffline_configure() async {
     // [START access_data_offline_configure_offline_persistence]
-    // Apple and Android
+    // Apple, Android and Web
     db.settings = const Settings(persistenceEnabled: true);
-
-    // Web
-    await db
-        .enablePersistence(const PersistenceSettings(synchronizeTabs: true));
     // [END access_data_offline_configure_offline_persistence]
   }
 


### PR DESCRIPTION
This PR addresses the confusion around enabling offline persistence for web platforms in the cloud_firestore package.

## Risk Level
- [ ] No risk
- [ ] Somewhat Risky
- [ ] High risk

## Pre-submit checklist
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)